### PR TITLE
Create static Markdown-driven Next.js site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      REPO_NAME: ${{ github.event.repository.name }}
+      NEXT_TELEMETRY_DISABLED: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Export static site
+        run: npm run export
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,36 +1,18 @@
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
 # dependencies
 /node_modules
 /.pnp
 .pnp.js
 
-# testing
-/coverage
-
 # next.js
-/.next/
-/out/
+/.next
+/out
 
 # production
 /build
 
 # misc
 .DS_Store
-*.pem
-
-# debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# local env files
-.env*.local
-.env
-
-# vercel
-.vercel
-
-# typescript
-*.tsbuildinfo
-next-env.d.ts
+/.cache

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# articles-website
+# Static Articles Site
+
+A static Next.js (App Router) site that renders Markdown articles with toggleable summary and full views. Designed for deployment to GitHub Pages using `next export`.
+
+## Getting Started
+
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Visit http://localhost:3000 to see the site. Articles live in `content/articles` and are parsed at build time.
+
+## Building & Exporting
+
+Create a production build and generate the static export:
+
+```bash
+npm run build
+npm run export
+```
+
+The static files are emitted to the `out/` directory and can be served locally or deployed to GitHub Pages.
+
+## GitHub Pages Deployment
+
+1. Ensure GitHub Pages is configured to use GitHub Actions.
+2. Push changes to the `main` branch. The included workflow (`.github/workflows/pages.yml`) builds the project and deploys the `out/` directory.
+3. The workflow sets the `REPO_NAME` environment variable automatically from the repository name, ensuring the correct `basePath` and `assetPrefix` for project pages.
+
+If you host the site under a different domain, set the `SITE_URL` environment variable during the build.
+
+## Content Model
+
+Articles are Markdown files with YAML frontmatter stored in `content/articles`. Required fields include `title`, `slug`, and `date`. Optional fields: `tags`, `summary`, and `cover`.
+
+## Scripts
+
+- `npm run dev` – start the dev server
+- `npm run build` – build for production
+- `npm run export` – generate static output for GitHub Pages
+- `npm run lint` – run Next.js linting
+
+## Base Path Notes
+
+When deployed to `https://USERNAME.github.io/REPO_NAME`, the site automatically uses `/REPO_NAME` as the base path. Locally, the base path is omitted.

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ArticleViewToggle } from '../../../components/ArticleViewToggle';
+import { ArticleContent } from '../../../components/ArticleContent';
+import { getAllArticles, getArticleBySlug, getArticleCanonicalUrl } from '../../../lib/content';
+
+export async function generateStaticParams() {
+  const articles = await getAllArticles();
+  return articles.map((article) => ({ slug: article.slug }));
+}
+
+type PageProps = {
+  params: { slug: string };
+};
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const article = await getArticleBySlug(params.slug);
+  if (!article) {
+    return {};
+  }
+  return {
+    title: article.title,
+    description: article.summary,
+    alternates: {
+      canonical: getArticleCanonicalUrl(article.slug),
+    },
+  };
+}
+
+export default async function ArticlePage({ params }: PageProps) {
+  const article = await getArticleBySlug(params.slug);
+  if (!article) {
+    notFound();
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <span className="text-sm uppercase tracking-wide text-slate-500 dark:text-slate-400">Article view</span>
+        <ArticleViewToggle />
+      </div>
+      <ArticleContent article={article} />
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100;
+}
+
+a {
+  @apply text-blue-600 dark:text-blue-400;
+}
+
+main {
+  @apply min-h-screen;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,50 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ViewPreferenceProvider } from '../components/ViewPreferenceContext';
+import { GlobalViewToggle } from '../components/ArticleViewToggle';
+import { getBasePath } from '../lib/paths';
+
+export const metadata: Metadata = {
+  title: {
+    default: 'Static Articles',
+    template: '%s | Static Articles',
+  },
+  description: 'A static Next.js knowledge base with full and summarized views.',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen bg-slate-50 text-slate-900 transition-colors dark:bg-slate-950 dark:text-slate-100">
+        <ViewPreferenceProvider>
+          <div className="flex min-h-screen flex-col">
+            <header className="border-b border-slate-200 bg-white/70 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
+              <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-4 px-4 py-5">
+                <Link href={`${getBasePath()}/`} className="text-xl font-semibold">
+                  Static Articles
+                </Link>
+                <GlobalViewToggle />
+              </div>
+            </header>
+            <main className="flex-1">
+              <div className="mx-auto w-full max-w-5xl px-4 py-8">{children}</div>
+            </main>
+            <footer className="border-t border-slate-200 bg-white/70 py-6 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/70">
+              <div className="mx-auto flex w-full max-w-5xl justify-between px-4">
+                <span>© {new Date().getFullYear()} Static Articles</span>
+                <a href="https://nextjs.org" target="_blank" rel="noopener noreferrer">
+                  Built with Next.js
+                </a>
+              </div>
+            </footer>
+          </div>
+        </ViewPreferenceProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import { withBasePath } from '../lib/paths';
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
+      <h1 className="text-6xl font-bold text-slate-900 dark:text-slate-100">404</h1>
+      <p className="text-lg text-slate-600 dark:text-slate-300">Sorry, we couldn&apos;t find that page.</p>
+      <Link
+        href={withBasePath('/')}
+        className="inline-flex items-center rounded-full bg-blue-600 px-6 py-2 text-sm font-semibold text-white shadow hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400"
+      >
+        Return home
+      </Link>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next';
+import { getAllArticles } from '../lib/content';
+import { ArticleCard } from '../components/ArticleCard';
+
+export const metadata: Metadata = {
+  title: 'Articles',
+  description: 'Browse articles with summary and full views.',
+};
+
+export default async function HomePage() {
+  const articles = await getAllArticles();
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section className="flex flex-col gap-6">
+        <div className="space-y-2">
+          <h1 className="text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">Latest Articles</h1>
+          <p className="text-lg text-slate-600 dark:text-slate-300">
+            Toggle between concise summaries and full content using the control in the header.
+          </p>
+        </div>
+        <div className="flex flex-col gap-6">
+          {articles.map((article) => (
+            <ArticleCard key={article.slug} article={article} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+import { getSiteUrl } from '../lib/site';
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = getSiteUrl();
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ArticleCard } from '../../../components/ArticleCard';
+import { getAllArticles, getAllTags } from '../../../lib/content';
+
+export async function generateStaticParams() {
+  const tags = await getAllTags();
+  return tags.map((tag) => ({ tag }));
+}
+
+type PageProps = {
+  params: { tag: string };
+};
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const tag = decodeURIComponent(params.tag);
+  const tags = await getAllTags();
+  if (!tags.includes(tag)) {
+    return {};
+  }
+  return {
+    title: `Tag: ${tag}`,
+    description: `Articles tagged with ${tag}.`,
+  };
+}
+
+export default async function TagPage({ params }: PageProps) {
+  const tag = decodeURIComponent(params.tag);
+  const tags = await getAllTags();
+  if (!tags.includes(tag)) {
+    notFound();
+  }
+  const articles = (await getAllArticles()).filter((article) => article.tags.includes(tag));
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="space-y-2">
+        <h1 className="text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">Tag: {tag}</h1>
+        <p className="text-lg text-slate-600 dark:text-slate-300">
+          Showing {articles.length} {articles.length === 1 ? 'article' : 'articles'} tagged with #{tag}.
+        </p>
+      </div>
+      <div className="flex flex-col gap-6">
+        {articles.map((article) => (
+          <ArticleCard key={article.slug} article={article} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Link from 'next/link';
+import clsx from 'clsx';
+import { Article } from '../lib/content';
+import { formatDate } from '../lib/format';
+import { MarkdownRenderer } from './MarkdownRenderer';
+import { TagBadge } from './TagBadge';
+import { useViewPreference } from './ViewPreferenceContext';
+import { withBasePath } from '../lib/paths';
+
+export function ArticleCard({ article }: { article: Article }) {
+  const { view } = useViewPreference();
+  const isSummary = view === 'summary';
+  const articleHref = `${withBasePath(`/articles/${article.slug}/`)}?view=${view}`;
+
+  return (
+    <article className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm transition-colors hover:border-blue-500 dark:border-slate-800 dark:bg-slate-900/70">
+      <header className="flex flex-col gap-2">
+        <Link href={articleHref} className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+          {article.title}
+        </Link>
+        <div className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <time dateTime={article.date}>{formatDate(article.date)}</time>
+          <span aria-hidden="true">•</span>
+          <span>{article.readingTime.text}</span>
+        </div>
+        {article.tags.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {article.tags.map((tag) => (
+              <TagBadge key={tag} tag={tag} />
+            ))}
+          </div>
+        )}
+      </header>
+      {isSummary ? (
+        <p className="text-base text-slate-600 dark:text-slate-300">{article.summary}</p>
+      ) : (
+        <MarkdownRenderer html={article.html} className="text-base" />
+      )}
+      <div>
+        <Link
+          href={articleHref}
+          className={clsx(
+            'inline-flex items-center gap-2 text-sm font-semibold text-blue-600 hover:underline dark:text-blue-400'
+          )}
+        >
+          Read →
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/components/ArticleContent.tsx
+++ b/components/ArticleContent.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Article } from '../lib/content';
+import Image from 'next/image';
+import { MarkdownRenderer } from './MarkdownRenderer';
+import { useIsSummaryView } from './ArticleViewToggle';
+import { formatDate } from '../lib/format';
+import { TagBadge } from './TagBadge';
+import { withBasePath } from '../lib/paths';
+
+export function ArticleContent({ article }: { article: Article }) {
+  const isSummary = useIsSummaryView();
+
+  return (
+    <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_280px] lg:gap-16">
+      <article className="prose prose-lg prose-slate max-w-none dark:prose-invert">
+        <header className="not-prose mb-8 flex flex-col gap-4">
+          <div className="space-y-2">
+            <h1 className="text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">{article.title}</h1>
+            <div className="flex flex-wrap items-center gap-3 text-sm text-slate-500 dark:text-slate-400">
+              <time dateTime={article.date}>{formatDate(article.date)}</time>
+              <span aria-hidden="true">•</span>
+              <span>{article.readingTime.text}</span>
+            </div>
+          </div>
+          {article.tags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {article.tags.map((tag) => (
+                <TagBadge key={tag} tag={tag} />
+              ))}
+            </div>
+          )}
+        </header>
+        {article.cover && !isSummary && (
+          <figure className="not-prose overflow-hidden rounded-3xl border border-slate-200 shadow-sm dark:border-slate-800">
+            <Image
+              src={withBasePath(article.cover)}
+              alt={article.title}
+              width={1200}
+              height={630}
+              className="h-auto w-full object-cover"
+              priority
+            />
+          </figure>
+        )}
+        {isSummary ? (
+          <p className="text-lg text-slate-600 dark:text-slate-300">{article.summary}</p>
+        ) : (
+          <MarkdownRenderer html={article.html} />
+        )}
+      </article>
+      {!isSummary && article.headings.length > 0 && (
+        <nav className="top-24 hidden lg:sticky lg:block">
+          <div className="rounded-2xl border border-slate-200 bg-white/80 p-4 text-sm shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+            <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">On this page</h2>
+            <ul className="mt-3 space-y-2">
+              {article.headings.map((heading) => (
+                <li key={heading.id} className={heading.level > 2 ? 'ml-4' : undefined}>
+                  <a href={`#${heading.id}`} className="text-slate-600 hover:text-blue-600 dark:text-slate-300 dark:hover:text-blue-400">
+                    {heading.text}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/components/ArticleViewToggle.tsx
+++ b/components/ArticleViewToggle.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useMemo } from 'react';
+import clsx from 'clsx';
+import { useViewPreference } from './ViewPreferenceContext';
+
+const options = [
+  { value: 'summary', label: 'Summary' },
+  { value: 'full', label: 'Full' },
+] as const;
+
+export function ArticleViewToggle() {
+  const { view, setView } = useViewPreference();
+
+  return (
+    <div className="inline-flex items-center rounded-full border border-slate-200 bg-white p-1 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-900">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          className={clsx(
+            'rounded-full px-3 py-1 font-medium transition-colors',
+            view === option.value
+              ? 'bg-blue-600 text-white shadow dark:bg-blue-500'
+              : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+          )}
+          onClick={() => setView(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function GlobalViewToggle() {
+  return <ArticleViewToggle />;
+}
+
+export function useIsSummaryView() {
+  const { view } = useViewPreference();
+  return useMemo(() => view === 'summary', [view]);
+}

--- a/components/MarkdownRenderer.tsx
+++ b/components/MarkdownRenderer.tsx
@@ -1,0 +1,10 @@
+import clsx from 'clsx';
+
+export function MarkdownRenderer({ html, className }: { html: string; className?: string }) {
+  return (
+    <div
+      className={clsx('prose prose-slate max-w-none dark:prose-invert', className)}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/components/TagBadge.tsx
+++ b/components/TagBadge.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Link from 'next/link';
+import clsx from 'clsx';
+import { withBasePath } from '../lib/paths';
+import { useViewPreference } from './ViewPreferenceContext';
+
+export function TagBadge({ tag, className }: { tag: string; className?: string }) {
+  const { view } = useViewPreference();
+  const href = `${withBasePath(`/tags/${encodeURIComponent(tag)}/`)}?view=${view}`;
+  return (
+    <Link
+      href={href}
+      className={clsx(
+        'inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800',
+        className
+      )}
+    >
+      #{tag}
+    </Link>
+  );
+}

--- a/components/ViewPreferenceContext.tsx
+++ b/components/ViewPreferenceContext.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+type ViewMode = 'summary' | 'full';
+
+type ViewPreferenceContextValue = {
+  view: ViewMode;
+  setView: (view: ViewMode) => void;
+};
+
+const ViewPreferenceContext = createContext<ViewPreferenceContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'articles-site:view-mode';
+
+function normalizeView(value: string | null, fallback: ViewMode): ViewMode {
+  return value === 'summary' || value === 'full' ? value : fallback;
+}
+
+export function ViewPreferenceProvider({ children }: { children: React.ReactNode }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [stored, setStored] = useState<ViewMode | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const value = window.localStorage.getItem(STORAGE_KEY);
+    if (value === 'summary' || value === 'full') {
+      setStored(value);
+    }
+  }, []);
+
+  const fallbackView = pathname?.includes('/articles/') ? 'full' : 'summary';
+  const paramView = normalizeView(searchParams?.get('view'), stored ?? fallbackView);
+
+  const [view, setViewState] = useState<ViewMode>(paramView);
+  const pendingRef = useRef<ViewMode | null>(null);
+
+  useEffect(() => {
+    if (pendingRef.current && pendingRef.current !== paramView) {
+      return;
+    }
+    pendingRef.current = null;
+    setViewState(paramView);
+  }, [paramView]);
+
+  const setView = (nextView: ViewMode) => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, nextView);
+    }
+    setStored(nextView);
+    pendingRef.current = nextView;
+    setViewState(nextView);
+  };
+
+  useEffect(() => {
+    const current = searchParams?.get('view');
+    if (!pathname) return;
+    if (current === view) {
+      return;
+    }
+    const params = new URLSearchParams(searchParams?.toString());
+    params.set('view', view);
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }, [view, pathname, router, searchParams]);
+
+  const value = useMemo(() => ({ view, setView }), [view]);
+
+  return <ViewPreferenceContext.Provider value={value}>{children}</ViewPreferenceContext.Provider>;
+}
+
+export function useViewPreference(): ViewPreferenceContextValue {
+  const context = useContext(ViewPreferenceContext);
+  if (!context) {
+    throw new Error('useViewPreference must be used within ViewPreferenceProvider');
+  }
+  return context;
+}
+
+export type { ViewMode };

--- a/content/articles/content-workflows.md
+++ b/content/articles/content-workflows.md
@@ -1,0 +1,22 @@
+---
+title: Content Workflows for Engineering Teams
+slug: content-workflows
+date: 2024-02-02
+tags:
+  - process
+  - teams
+---
+
+Creating documentation that engineers love requires a workflow that respects code review, version control, and automation.
+
+### Treat Docs Like Code
+
+Use pull requests and review tools to ensure every edit has context and accountability. Templates for PR descriptions help reviewers focus on clarity.
+
+### Automate Checks
+
+Lint markdown, enforce style guides, and generate previews. Automation keeps quality high and frees maintainers from repetitive tasks.
+
+### Celebrate Updates
+
+Share doc changes in team meetings or Slack channels. Visibility encourages contributions and keeps knowledge fresh.

--- a/content/articles/speed-up-ci.md
+++ b/content/articles/speed-up-ci.md
@@ -1,0 +1,23 @@
+---
+title: Speed Up Your CI Pipeline
+slug: speed-up-ci
+date: 2024-01-15
+tags:
+  - devops
+  - ci
+summary: Practical tips for reducing build times and keeping feedback loops tight in continuous integration systems.
+---
+
+Continuous integration is only valuable when feedback is fast. Here are a few tactics that have helped teams shorten their pipelines.
+
+### Cache Dependencies Aggressively
+
+Store package caches between builds. Whether you use npm, pnpm, or yarn, caching dependencies can shave minutes from every run.
+
+### Split Long Jobs
+
+Break monolithic jobs into stages that can run in parallel. For example, linting, unit tests, and integration tests can often run simultaneously.
+
+### Use Targeted Triggers
+
+Avoid running the entire pipeline on documentation-only changes. Path filters in GitHub Actions and other CI platforms make this easy.

--- a/content/articles/static-sites-with-nextjs.md
+++ b/content/articles/static-sites-with-nextjs.md
@@ -1,0 +1,33 @@
+---
+title: Building Static Sites with Next.js
+slug: static-sites-with-nextjs
+date: 2024-03-12
+tags:
+  - nextjs
+  - guides
+summary: Learn how to configure Next.js for static exports, including base paths, sitemap generation, and GitHub Pages deployment.
+cover: /images/static-sites.svg
+---
+
+## Why Static Exports Matter
+
+Static exports unlock fast hosting options, predictable deployments, and a simpler runtime. With `next export`, you can deploy to GitHub Pages or any CDN without servers.
+
+## Configure Next.js
+
+To enable static exports, set `output: 'export'` in `next.config.js`. Combine this with a `basePath` when deploying to a project page on GitHub Pages.
+
+```
+/** @type {import('next').NextConfig} */
+const config = {
+  output: 'export',
+  basePath: '/my-project',
+  trailingSlash: true,
+};
+
+module.exports = config;
+```
+
+## Deploy to GitHub Pages
+
+Use GitHub Actions to build and export. Upload the `out/` directory as a Pages artifact and deploy. Remember to set `REPO_NAME` so that asset paths resolve correctly.

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,0 +1,181 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import readingTime from 'reading-time';
+import { markdownToHtml, extractHeadings, Heading } from './md';
+import { generateSummary } from './summaries';
+import { getCanonicalUrl, getSiteUrl } from './site';
+
+export type Article = {
+  slug: string;
+  title: string;
+  date: string;
+  tags: string[];
+  summary: string;
+  cover?: string | null;
+  content: string;
+  html: string;
+  headings: Heading[];
+  readingTime: {
+    text: string;
+    minutes: number;
+    words: number;
+  };
+};
+
+let cachePromise: Promise<Article[]> | null = null;
+
+function getArticlesDirectory() {
+  return path.join(process.cwd(), 'content', 'articles');
+}
+
+function validateFrontmatter(data: Record<string, unknown>, filePath: string) {
+  const requiredFields: Array<[string, (value: unknown) => boolean, string]> = [
+    ['title', (value) => typeof value === 'string' && value.trim().length > 0, 'a non-empty string'],
+    ['date', (value) => typeof value === 'string' && !Number.isNaN(Date.parse(value)), 'an ISO8601 string'],
+  ];
+
+  for (const [field, validator, description] of requiredFields) {
+    if (!validator(data[field])) {
+      throw new Error(`Invalid frontmatter in ${filePath}: "${field}" must be ${description}.`);
+    }
+  }
+}
+
+async function loadArticlesFromDisk(): Promise<Article[]> {
+  const dir = getArticlesDirectory();
+  if (!fs.existsSync(dir)) {
+    throw new Error(`Content directory not found: ${dir}`);
+  }
+  const files = fs.readdirSync(dir).filter((file) => file.endsWith('.md'));
+
+  const articles: Article[] = [];
+
+  for (const file of files) {
+    const fullPath = path.join(dir, file);
+    const fileContents = fs.readFileSync(fullPath, 'utf8');
+    const { data, content } = matter(fileContents);
+
+    validateFrontmatter(data, fullPath);
+
+    const slug = (typeof data.slug === 'string' && data.slug.trim().length > 0
+      ? data.slug.trim()
+      : path.basename(file, path.extname(file))
+    ).replace(/\s+/g, '-');
+
+    const html = await markdownToHtml(content);
+    const summary = await generateSummary(content, typeof data.summary === 'string' ? data.summary : undefined);
+    const headings = extractHeadings(content);
+    const reading = readingTime(content);
+
+    const article: Article = {
+      slug,
+      title: data.title as string,
+      date: new Date(data.date as string).toISOString(),
+      tags: Array.isArray(data.tags) ? (data.tags as unknown[]).filter((tag): tag is string => typeof tag === 'string') : [],
+      summary,
+      cover: typeof data.cover === 'string' ? data.cover : null,
+      content,
+      html,
+      headings,
+      readingTime: {
+        text: reading.text,
+        minutes: reading.minutes,
+        words: reading.words,
+      },
+    };
+
+    articles.push(article);
+  }
+
+  articles.sort((a, b) => (a.date > b.date ? -1 : 1));
+
+  persistArticleCache(articles);
+  generateSitemap(articles);
+  generateRss(articles);
+
+  return articles;
+}
+
+function persistArticleCache(articles: Article[]) {
+  const cacheDir = path.join(process.cwd(), '.cache');
+  if (!fs.existsSync(cacheDir)) {
+    fs.mkdirSync(cacheDir, { recursive: true });
+  }
+  const cachePath = path.join(cacheDir, 'articles.json');
+  fs.writeFileSync(cachePath, JSON.stringify(articles, null, 2), 'utf8');
+}
+
+function generateSitemap(articles: Article[]) {
+  const siteUrl = getSiteUrl();
+  const tagSet = new Set<string>();
+  for (const article of articles) {
+    for (const tag of article.tags) {
+      tagSet.add(tag);
+    }
+  }
+
+  const pages = [
+    `${siteUrl}/`,
+    ...articles.map((article) => `${siteUrl}/articles/${article.slug}/`),
+    ...Array.from(tagSet).map((tag) => `${siteUrl}/tags/${encodeURIComponent(tag)}/`),
+  ];
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' +
+    pages
+      .map((url) => `<url><loc>${url}</loc></url>`)
+      .join('') +
+    '</urlset>';
+
+  const publicDir = path.join(process.cwd(), 'public');
+  if (!fs.existsSync(publicDir)) {
+    fs.mkdirSync(publicDir, { recursive: true });
+  }
+  fs.writeFileSync(path.join(publicDir, 'sitemap.xml'), xml, 'utf8');
+}
+
+function generateRss(articles: Article[]) {
+  const siteUrl = getSiteUrl();
+  const items = articles
+    .map((article) => {
+      const link = `${siteUrl}/articles/${article.slug}/`;
+      return `\n  <item>\n    <title><![CDATA[${article.title}]]></title>\n    <link>${link}</link>\n    <guid>${link}</guid>\n    <pubDate>${new Date(article.date).toUTCString()}</pubDate>\n    <description><![CDATA[${article.summary}]]></description>\n  </item>`;
+    })
+    .join('');
+
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n<channel>\n  <title>Static Articles</title>\n  <link>${siteUrl}/</link>\n  <description>Latest articles from Static Articles</description>${items}\n</channel>\n</rss>`;
+
+  const publicDir = path.join(process.cwd(), 'public');
+  if (!fs.existsSync(publicDir)) {
+    fs.mkdirSync(publicDir, { recursive: true });
+  }
+  fs.writeFileSync(path.join(publicDir, 'rss.xml'), rss, 'utf8');
+}
+
+export async function getAllArticles(): Promise<Article[]> {
+  if (!cachePromise) {
+    cachePromise = loadArticlesFromDisk();
+  }
+  return cachePromise;
+}
+
+export async function getArticleBySlug(slug: string): Promise<Article | undefined> {
+  const articles = await getAllArticles();
+  return articles.find((article) => article.slug === slug);
+}
+
+export async function getAllTags(): Promise<string[]> {
+  const articles = await getAllArticles();
+  const set = new Set<string>();
+  for (const article of articles) {
+    for (const tag of article.tags) {
+      set.add(tag);
+    }
+  }
+  return Array.from(set).sort();
+}
+
+export function getArticleCanonicalUrl(slug: string) {
+  return getCanonicalUrl(`/articles/${slug}/`);
+}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,8 @@
+export function formatDate(value: string) {
+  const date = new Date(value);
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}

--- a/lib/md.ts
+++ b/lib/md.ts
@@ -1,0 +1,55 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkRehype from 'remark-rehype';
+import rehypeSlug from 'rehype-slug';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import rehypeRaw from 'rehype-raw';
+import rehypeStringify from 'rehype-stringify';
+import { remark } from 'remark';
+import { visit } from 'unist-util-visit';
+import { toString } from 'mdast-util-to-string';
+import GithubSlugger from 'github-slugger';
+
+export async function markdownToHtml(markdown: string): Promise<string> {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeSlug)
+    .use(rehypeAutolinkHeadings, {
+      behavior: 'wrap',
+    })
+    .use(rehypeStringify, { allowDangerousHtml: true })
+    .process(markdown);
+
+  return String(file);
+}
+
+export type Heading = {
+  id: string;
+  text: string;
+  level: number;
+};
+
+export function extractHeadings(markdown: string): Heading[] {
+  const tree = remark().use(remarkParse).parse(markdown);
+  const headings: Heading[] = [];
+  const slugger = new GithubSlugger();
+
+  visit(tree, 'heading', (node: any) => {
+    if (!node.depth || node.depth < 2 || node.depth > 4) {
+      return;
+    }
+    const text = toString(node).trim();
+    if (!text) return;
+    headings.push({
+      id: slugger.slug(text),
+      text,
+      level: node.depth,
+    });
+  });
+
+  return headings;
+}

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -1,0 +1,12 @@
+const repoName = process.env.NEXT_PUBLIC_REPO_NAME || process.env.REPO_NAME || '';
+
+export function getBasePath(): string {
+  return repoName ? `/${repoName}` : '';
+}
+
+export function withBasePath(path: string): string {
+  const base = getBasePath();
+  if (!base) return path;
+  if (path.startsWith(base)) return path;
+  return `${base}${path.startsWith('/') ? path : `/${path}`}`;
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,18 @@
+const repoName = process.env.REPO_NAME || '';
+const siteUrlEnv = process.env.SITE_URL || '';
+
+export function getSiteUrl(): string {
+  if (siteUrlEnv) {
+    return siteUrlEnv.replace(/\/$/, '');
+  }
+  const defaultHost = 'https://example.com';
+  return repoName ? `${defaultHost}/${repoName}` : defaultHost;
+}
+
+export function getCanonicalUrl(pathname: string): string {
+  const site = getSiteUrl();
+  if (!pathname.startsWith('/')) {
+    return `${site}/${pathname}`;
+  }
+  return `${site}${pathname}`;
+}

--- a/lib/summaries.ts
+++ b/lib/summaries.ts
@@ -1,0 +1,23 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import strip from 'strip-markdown';
+
+const SUMMARY_WORD_TARGET = 150;
+
+function truncateToWordLimit(text: string, limit: number): string {
+  const words = text.trim().split(/\s+/);
+  if (words.length <= limit) {
+    return text.trim();
+  }
+  return `${words.slice(0, limit).join(' ')}…`;
+}
+
+export async function generateSummary(markdown: string, fallback?: string): Promise<string> {
+  if (fallback && fallback.trim().length > 0) {
+    return fallback.trim();
+  }
+
+  const stripped = await unified().use(remarkParse).use(strip).process(markdown);
+  const plain = String(stripped).replace(/\s+/g, ' ').trim();
+  return truncateToWordLimit(plain, SUMMARY_WORD_TARGET);
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+declare module '*.md' {
+  const content: string;
+  export default content;
+}
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,18 @@
+const repoName = process.env.REPO_NAME || '';
+const basePath = repoName ? `/${repoName}` : '';
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  basePath,
+  assetPrefix: basePath,
+  images: {
+    unoptimized: true,
+  },
+  trailingSlash: true,
+  experimental: {
+    optimizeCss: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "articles-website",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "export": "next export",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "github-slugger": "^2.0.0",
+    "gray-matter": "^4.0.3",
+    "mdast-util-to-string": "^4.0.0",
+    "next": "14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "reading-time": "^1.5.0",
+    "rehype-autolink-headings": "^7.1.0",
+    "rehype-raw": "^6.1.1",
+    "rehype-slug": "^6.1.0",
+    "rehype-stringify": "^10.0.0",
+    "remark": "^15.0.1",
+    "remark-gfm": "^4.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.0",
+    "strip-markdown": "^5.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/typography": "^0.5.10",
+    "@types/node": "^20.11.24",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.4"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/images/static-sites.svg
+++ b/public/images/static-sites.svg
@@ -1,0 +1,18 @@
+<svg width="800" height="400" viewBox="0 0 800 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Static Sites Illustration</title>
+  <desc id="desc">Abstract gradient illustrating static site generation.</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#60a5fa" />
+      <stop offset="100%" stop-color="#7c3aed" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="400" fill="url(#gradient)" rx="32" />
+  <g fill="white" opacity="0.8">
+    <circle cx="140" cy="120" r="40" />
+    <rect x="220" y="90" width="180" height="60" rx="12" />
+    <rect x="440" y="70" width="240" height="100" rx="16" />
+    <rect x="120" y="220" width="220" height="120" rx="20" />
+    <rect x="380" y="220" width="300" height="120" rx="24" />
+  </g>
+</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+    './lib/**/*.{js,ts,jsx,tsx}',
+    './content/**/*.{md,mdx}',
+  ],
+  theme: {
+    extend: {
+      typography: {
+        DEFAULT: {
+          css: {
+            'code::before': { content: 'none' },
+            'code::after': { content: 'none' },
+          },
+        },
+      },
+    },
+  },
+  plugins: [require('@tailwindcss/typography')],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a static Next.js App Router site with Tailwind styling and a global summary/full view toggle synced via URL and localStorage
- implement filesystem-backed markdown parsing with automatic summaries, table-of-contents generation, and sitemap/RSS outputs
- add GitHub Pages export configuration, deployment workflow, and sample articles with accompanying documentation

## Testing
- Tests were not run (npm install blocked by 403 errors in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd6ef9b2a88325ad90104e918d048b