### PR TITLE
Use manual summary files and update summary handling

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
   return {
     title: article.title,
-    description: article.summary,
+    description: article.summary.text,
     alternates: {
       canonical: getArticleCanonicalUrl(article.slug),
     },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import './globals.css';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { ViewPreferenceProvider } from '../components/ViewPreferenceContext';
-import { GlobalViewToggle } from '../components/ArticleViewToggle';
 import { getBasePath } from '../lib/paths';
 
 export const metadata: Metadata = {
@@ -28,7 +27,6 @@ export default function RootLayout({
                 <Link href={`${getBasePath()}/`} className="text-xl font-semibold">
                   Static Articles
                 </Link>
-                <GlobalViewToggle />
               </div>
             </header>
             <main className="flex-1">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
 import { getAllArticles } from '../lib/content';
 import { ArticleCard } from '../components/ArticleCard';
+import { ArticleViewToggle } from '../components/ArticleViewToggle';
 
 export const metadata: Metadata = {
   title: 'Articles',
-  description: 'Browse articles with summary and full views.',
+  description: 'Browse articles with hand-written summaries or dive into the full content.',
 };
 
 export default async function HomePage() {
@@ -13,11 +14,19 @@ export default async function HomePage() {
   return (
     <div className="flex flex-col gap-8">
       <section className="flex flex-col gap-6">
-        <div className="space-y-2">
-          <h1 className="text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">Latest Articles</h1>
-          <p className="text-lg text-slate-600 dark:text-slate-300">
-            Toggle between concise summaries and full content using the control in the header.
-          </p>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-2">
+            <h1 className="text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">Latest Articles</h1>
+            <p className="text-lg text-slate-600 dark:text-slate-300">
+              Choose a hand-crafted overview or the complete write-up for each topic.
+            </p>
+          </div>
+          <div className="flex flex-col items-start gap-2 sm:items-end">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              List view
+            </span>
+            <ArticleViewToggle />
+          </div>
         </div>
         <div className="flex flex-col gap-6">
           {articles.map((article) => (

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -34,7 +34,10 @@ export function ArticleCard({ article }: { article: Article }) {
         )}
       </header>
       {isSummary ? (
-        <p className="text-base text-slate-600 dark:text-slate-300">{article.summary}</p>
+        <MarkdownRenderer
+          html={article.summary.html}
+          className="prose-sm text-slate-600 dark:text-slate-300 [&>*:last-child]:mb-0"
+        />
       ) : (
         <MarkdownRenderer html={article.html} className="text-base" />
       )}

--- a/components/ArticleContent.tsx
+++ b/components/ArticleContent.tsx
@@ -44,7 +44,10 @@ export function ArticleContent({ article }: { article: Article }) {
           </figure>
         )}
         {isSummary ? (
-          <p className="text-lg text-slate-600 dark:text-slate-300">{article.summary}</p>
+          <MarkdownRenderer
+            html={article.summary.html}
+            className="prose-lg text-slate-600 dark:text-slate-300"
+          />
         ) : (
           <MarkdownRenderer html={article.html} />
         )}

--- a/content/articles/speed-up-ci.md
+++ b/content/articles/speed-up-ci.md
@@ -5,7 +5,6 @@ date: 2024-01-15
 tags:
   - devops
   - ci
-summary: Practical tips for reducing build times and keeping feedback loops tight in continuous integration systems.
 ---
 
 Continuous integration is only valuable when feedback is fast. Here are a few tactics that have helped teams shorten their pipelines.

--- a/content/articles/static-sites-with-nextjs.md
+++ b/content/articles/static-sites-with-nextjs.md
@@ -5,7 +5,6 @@ date: 2024-03-12
 tags:
   - nextjs
   - guides
-summary: Learn how to configure Next.js for static exports, including base paths, sitemap generation, and GitHub Pages deployment.
 cover: /images/static-sites.svg
 ---
 

--- a/content/summaries/content-workflows.md
+++ b/content/summaries/content-workflows.md
@@ -1,0 +1,1 @@
+Creating engineering documentation that sticks means treating it like code. Run changes through pull requests with review templates so updates are contextual and accountable, automate linting and preview builds to keep quality high without manual effort, and broadcast merged improvements so the team sees the docs as a living, celebrated part of the workflow.

--- a/content/summaries/speed-up-ci.md
+++ b/content/summaries/speed-up-ci.md
@@ -1,0 +1,1 @@
+Fast feedback in CI comes from shaving off waits everywhere. Cache dependencies between builds, split slow pipelines into parallel jobs, and trigger heavy steps only when relevant files change so developers stay in the loop without watching progress bars.

--- a/content/summaries/static-sites-with-nextjs.md
+++ b/content/summaries/static-sites-with-nextjs.md
@@ -1,0 +1,1 @@
+Shipping Next.js as a static site is about a predictable build plus the right deployment wiring. Enable `output: 'export'`, set a base path when serving from a project subdirectory, and use GitHub Actions to export and publish the `out/` folder so assets resolve cleanly on GitHub Pages or any CDN.

--- a/lib/summaries.ts
+++ b/lib/summaries.ts
@@ -13,16 +13,20 @@ function truncateToWordLimit(text: string, limit: number): string {
   return `${words.slice(0, limit).join(' ')}…`;
 }
 
-export async function generateSummary(markdown: string, fallback?: string): Promise<string> {
-  if (fallback && fallback.trim().length > 0) {
-    return fallback.trim();
-  }
-
+export async function markdownToPlainText(markdown: string): Promise<string> {
   const stripped = await unified()
     .use(remarkParse)
     .use(strip as any)
     .use(remarkStringify)
     .process(markdown);
-  const plain = String(stripped).replace(/\s+/g, ' ').trim();
+  return String(stripped).replace(/\s+/g, ' ').trim();
+}
+
+export async function generateSummary(markdown: string, fallback?: string): Promise<string> {
+  if (fallback && fallback.trim().length > 0) {
+    return fallback.trim();
+  }
+
+  const plain = await markdownToPlainText(markdown);
   return truncateToWordLimit(plain, SUMMARY_WORD_TARGET);
 }


### PR DESCRIPTION
## Summary
- remove the header-level summary toggle and add a list view toggle on the home page
- read hand-written article summaries from dedicated markdown files and render them through the summary view
- update metadata and RSS generation to use the manual summary text

## Testing
- not run (next lint prompts for interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68ebd6ca0cb48325a3fbb071f4836bd3