### PR TITLE
Fix article links to respect Next.js basePath

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import { withBasePath } from '../lib/paths';
 
 export const runtime = 'nodejs';           // ensure Node runtime (fs available)
 export const dynamic = 'force-static';     // keep SSG if you’re reading local files
@@ -10,7 +9,7 @@ export default function NotFound() {
       <h1 className="text-6xl font-bold text-slate-900 dark:text-slate-100">404</h1>
       <p className="text-lg text-slate-600 dark:text-slate-300">Sorry, we couldn&apos;t find that page.</p>
       <Link
-        href={withBasePath('/')}
+        href="/"
         className="inline-flex items-center rounded-full bg-blue-600 px-6 py-2 text-sm font-semibold text-white shadow hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400"
       >
         Return home

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { getAllArticles } from '../lib/content';
 import type { Article } from '../lib/content';
 import { ArticlePreviewCard } from '../components/ArticlePreviewCard';
-import { withBasePath } from '../lib/paths';
 
 export const runtime = 'nodejs';           // ensure Node runtime (fs available)
 export const dynamic = 'force-static';     // keep SSG if you’re reading local files
@@ -80,10 +79,7 @@ export default async function HomePage() {
                 Fresh insights and guides, each condensed into a quick preview so you can dive into what matters.
               </p>
             </div>
-            <Link
-              href={withBasePath('/')}
-              className="text-sm font-semibold text-blue-600 hover:underline dark:text-blue-400"
-            >
+            <Link href="/" className="text-sm font-semibold text-blue-600 hover:underline dark:text-blue-400">
               View all articles
             </Link>
           </div>
@@ -107,7 +103,7 @@ export default async function HomePage() {
             {popularTopics.map(([tag, info]) => (
               <Link
                 key={tag}
-                href={withBasePath(`/tags/${encodeURIComponent(tag)}/`)}
+                href={`/tags/${encodeURIComponent(tag)}/`}
                 className="group rounded-2xl border border-slate-200 bg-white/70 p-5 shadow-sm transition hover:border-blue-500 hover:shadow-md dark:border-slate-800 dark:bg-slate-900/60"
               >
                 <div className="flex flex-col gap-3">

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -7,12 +7,11 @@ import { formatDate } from '../lib/format';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { TagBadge } from './TagBadge';
 import { useViewPreference } from './ViewPreferenceContext';
-import { withBasePath } from '../lib/paths';
 
 export function ArticleCard({ article }: { article: Article }) {
   const { view } = useViewPreference();
   const isSummary = view === 'summary';
-  const articleHref = `${withBasePath(`/articles/${article.slug}/`)}?view=${view}`;
+  const articleHref = `/articles/${article.slug}/?view=${view}`;
 
   return (
     <article className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm transition-colors hover:border-blue-500 dark:border-slate-800 dark:bg-slate-900/70">

--- a/components/ArticlePreviewCard.tsx
+++ b/components/ArticlePreviewCard.tsx
@@ -21,7 +21,7 @@ type ArticlePreviewCardProps = {
 };
 
 export function ArticlePreviewCard({ article, variant = 'default', className }: ArticlePreviewCardProps) {
-  const href = withBasePath(`/articles/${article.slug}/`);
+  const href = `/articles/${article.slug}/`;
   const summary = article.summary;
   const excerptLength = variant === 'featured' ? 220 : variant === 'compact' ? 140 : 160;
   const excerpt = truncate(summary.text, excerptLength);

--- a/components/TagBadge.tsx
+++ b/components/TagBadge.tsx
@@ -2,12 +2,11 @@
 
 import Link from 'next/link';
 import clsx from 'clsx';
-import { withBasePath } from '../lib/paths';
 import { useViewPreference } from './ViewPreferenceContext';
 
 export function TagBadge({ tag, className }: { tag: string; className?: string }) {
   const { view } = useViewPreference();
-  const href = `${withBasePath(`/tags/${encodeURIComponent(tag)}/`)}?view=${view}`;
+  const href = `/tags/${encodeURIComponent(tag)}/?view=${view}`;
   return (
     <Link
       href={href}


### PR DESCRIPTION
## Summary
- remove manual base path prefixes from internal Next.js Link components
- ensure article and tag links still include the view query parameter while avoiding duplicated repo paths
- update homepage and 404 links to rely on Next.js basePath handling

## Testing
- npm run build *(fails: Type error: Cannot find module 'remark-stringify')*

------
https://chatgpt.com/codex/tasks/task_e_68ec0253fcc88325a18b2938ce3f229f