### PR TITLE
Add header theme toggle control

### DIFF
--- a/components/SiteShell.tsx
+++ b/components/SiteShell.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 import type { Collection, SubjectNode } from '../lib/content/types';
 import { getBasePath } from '../lib/paths';
 import { TreeNavigation } from './TreeNavigation';
+import { ThemeToggle } from './ThemeToggle';
 
 type SiteShellProps = {
   tree: SubjectNode;
@@ -22,9 +23,12 @@ export function SiteShell({ tree, collections, children }: SiteShellProps) {
           <Link href={`${basePath}/`} className="text-xl font-semibold tracking-tight">
             Sid Makes Sense
           </Link>
-          <span className="hidden text-sm font-medium text-muted-foreground sm:inline-flex">
-            Personal blog by Sidnei Teixeira
-          </span>
+          <div className="flex items-center gap-3">
+            <span className="hidden text-sm font-medium text-muted-foreground sm:inline-flex">
+              Personal blog by Sidnei Teixeira
+            </span>
+            <ThemeToggle />
+          </div>
         </div>
       </header>
 

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+
+import { Button } from './ui/button';
+import { cn } from '../lib/utils';
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isDark = resolvedTheme === 'dark';
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      className="relative"
+    >
+      <Sun
+        className={cn(
+          'h-5 w-5 transition-all duration-200',
+          mounted && isDark ? 'scale-0 rotate-90 opacity-0' : 'scale-100 rotate-0 opacity-100'
+        )}
+      />
+      <Moon
+        className={cn(
+          'absolute h-5 w-5 transition-all duration-200',
+          mounted && isDark ? 'scale-100 rotate-0 opacity-100' : 'scale-0 -rotate-90 opacity-0'
+        )}
+      />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side ThemeToggle component that flips between light and dark palettes using next-themes
- surface the toggle in the site header so readers can switch between light and dark modes

## Testing
- npm run lint *(fails: interactive eslint setup prompt in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f526b084108325836a6f28023b3056