### PR TITLE
Fix article URLs for collection chapters

### DIFF
--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -5,9 +5,10 @@ import { Article } from '../lib/content/types';
 import { formatDate } from '../lib/format';
 import { TagBadge } from './TagBadge';
 import { Card, CardContent } from './ui/card';
+import { getArticleHref } from '../lib/content/routes';
 
 export function ArticleCard({ article }: { article: Article }) {
-  const articleHref = `/articles/${article.slug}/?view=full`;
+  const articleHref = `${getArticleHref(article.slug)}?view=full`;
 
   return (
     <Card className="group flex flex-col gap-5 overflow-hidden border-none border-border bg-card p-6 transition-all duration-300 hover:shadow-subtle">

--- a/components/ArticlePreviewCard.tsx
+++ b/components/ArticlePreviewCard.tsx
@@ -7,6 +7,7 @@ import { TagBadge } from './TagBadge';
 import { withBasePath } from '../lib/paths';
 import { Card, CardContent } from './ui/card';
 import { cn } from '../lib/utils';
+import { getArticleHref } from '../lib/content/routes';
 
 function truncate(text: string, length: number) {
   if (text.length <= length) return text;
@@ -25,7 +26,7 @@ type ArticlePreviewCardProps = {
 };
 
 export function ArticlePreviewCard({ article, variant = 'default', className, style }: ArticlePreviewCardProps) {
-  const href = `/articles/${article.slug}/`;
+  const href = getArticleHref(article.slug);
   const summary = article.summary;
   const excerptLength = variant === 'featured' ? 220 : variant === 'compact' ? 140 : 160;
   const excerpt = truncate(summary.text, excerptLength);

--- a/lib/content/routes.ts
+++ b/lib/content/routes.ts
@@ -1,0 +1,20 @@
+export function getArticleHref(slug: string): string {
+  if (typeof slug !== 'string' || slug.length === 0) {
+    return '/articles/';
+  }
+
+  if (slug.includes('/')) {
+    const segments = slug.split('/').filter(Boolean);
+    if (segments.length >= 2) {
+      const [collectionSlug, ...articleSegments] = segments;
+      const chapterPath = articleSegments.join('/');
+      return `/collections/${collectionSlug}/${chapterPath}/`;
+    }
+    const [collectionSlug] = segments;
+    if (collectionSlug) {
+      return `/collections/${collectionSlug}/`;
+    }
+  }
+
+  return `/articles/${slug}/`;
+}


### PR DESCRIPTION
## Summary
- add a shared helper to compute the correct URL for both standalone and collection articles
- update article cards to use the helper so collection chapters link to their collection route

## Testing
- not run (Next.js lint command prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68f526d6a7b08325a8ede705b4a2f063