### PR TITLE
Add animated tree navigation and resizable sidebar

### DIFF
--- a/components/SiteShell.tsx
+++ b/components/SiteShell.tsx
@@ -1,11 +1,24 @@
 'use client';
 
 import Link from 'next/link';
-import type { ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from 'react';
 import type { Collection, SubjectNode } from '../lib/content/types';
 import { getBasePath } from '../lib/paths';
+import { cn } from '../lib/utils';
 import { TreeNavigation } from './TreeNavigation';
 import { ThemeToggle } from './ThemeToggle';
+
+const DEFAULT_SIDEBAR_WIDTH = 288;
+const MIN_SIDEBAR_WIDTH = 224;
+const MAX_SIDEBAR_WIDTH = 460;
+const COLLAPSE_THRESHOLD = 80;
 
 type SiteShellProps = {
   tree: SubjectNode;
@@ -15,6 +28,91 @@ type SiteShellProps = {
 
 export function SiteShell({ tree, collections, children }: SiteShellProps) {
   const basePath = getBasePath();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const dragOriginRef = useRef(0);
+  const lastExpandedWidthRef = useRef(DEFAULT_SIDEBAR_WIDTH);
+  const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    if (!isSidebarCollapsed && sidebarWidth > 0) {
+      lastExpandedWidthRef.current = sidebarWidth;
+    }
+  }, [isSidebarCollapsed, sidebarWidth]);
+
+  const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const container = containerRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    dragOriginRef.current = rect.left;
+    setIsDragging(true);
+    event.preventDefault();
+  }, []);
+
+  const handleDoubleClick = useCallback(() => {
+    setIsSidebarCollapsed((prev) => {
+      if (prev) {
+        const restoredWidth = Math.min(
+          MAX_SIDEBAR_WIDTH,
+          Math.max(MIN_SIDEBAR_WIDTH, lastExpandedWidthRef.current || DEFAULT_SIDEBAR_WIDTH)
+        );
+        setSidebarWidth(restoredWidth);
+        return false;
+      }
+      lastExpandedWidthRef.current = sidebarWidth || DEFAULT_SIDEBAR_WIDTH;
+      setSidebarWidth(0);
+      return true;
+    });
+  }, [sidebarWidth]);
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const containerLeft = dragOriginRef.current;
+      const rawWidth = event.clientX - containerLeft;
+      const clampedWidth = Math.max(0, Math.min(MAX_SIDEBAR_WIDTH, rawWidth));
+
+      if (clampedWidth <= COLLAPSE_THRESHOLD) {
+        setIsSidebarCollapsed(true);
+        setSidebarWidth(0);
+        return;
+      }
+
+      const nextWidth = Math.max(MIN_SIDEBAR_WIDTH, clampedWidth);
+      lastExpandedWidthRef.current = nextWidth;
+      setSidebarWidth(nextWidth);
+      setIsSidebarCollapsed(false);
+    };
+
+    const stopDragging = () => {
+      setIsDragging(false);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', stopDragging);
+    window.addEventListener('pointercancel', stopDragging);
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', stopDragging);
+      window.removeEventListener('pointercancel', stopDragging);
+    };
+  }, [isDragging]);
+
+  useEffect(() => {
+    if (!isDragging) return;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    return () => {
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+    };
+  }, [isDragging]);
 
   return (
     <div className="relative flex min-h-screen flex-col">
@@ -38,13 +136,42 @@ export function SiteShell({ tree, collections, children }: SiteShellProps) {
         </div>
       </div>
 
-      <div className="flex flex-1">
-        <aside className="hidden w-72 shrink-0 border-r border-border bg-background backdrop-blur lg:block xl:w-80">
-          <div className="sticky top-[5.25rem] max-h-[calc(100vh-5.25rem)] overflow-y-auto px-4 py-6">
+      <div className="flex flex-1" ref={containerRef}>
+        <aside
+          className={cn(
+            'relative hidden shrink-0 overflow-hidden bg-background backdrop-blur transition-[width] duration-200 ease-out lg:flex',
+            isSidebarCollapsed ? 'border-r border-transparent' : 'border-r border-border'
+          )}
+          style={{
+            width: isSidebarCollapsed ? '0px' : `${sidebarWidth}px`,
+            minWidth: isSidebarCollapsed ? '0px' : `${sidebarWidth}px`,
+            transition: isDragging ? 'none' : 'width 0.2s ease',
+          }}
+        >
+          <div
+            className={cn(
+              'sticky top-[5.25rem] max-h-[calc(100vh-5.25rem)] overflow-y-auto px-4 py-6 transition-opacity duration-200',
+              isSidebarCollapsed ? 'pointer-events-none opacity-0' : 'opacity-100'
+            )}
+            aria-hidden={isSidebarCollapsed}
+          >
             <TreeNavigation tree={tree} collections={collections} />
           </div>
         </aside>
-        <main className="flex-1">
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize navigation"
+          tabIndex={-1}
+          className={cn(
+            'hidden w-2 cursor-col-resize select-none transition-colors duration-150 lg:block',
+            isDragging ? 'bg-border' : 'bg-transparent hover:bg-border/60'
+          )}
+          style={{ touchAction: 'none' }}
+          onPointerDown={handlePointerDown}
+          onDoubleClick={handleDoubleClick}
+        />
+        <main className="flex-1 min-w-0">
           <div className="mx-auto w-full max-w-7xl px-4 py-12 sm:py-16">{children}</div>
         </main>
       </div>

--- a/components/ui/collapsible.tsx
+++ b/components/ui/collapsible.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+type CollapsibleContextValue = {
+  open: boolean;
+  disabled: boolean;
+  setOpen: (open: boolean) => void;
+};
+
+const CollapsibleContext = React.createContext<CollapsibleContextValue | null>(null);
+
+function useCollapsibleContext(component: string): CollapsibleContextValue {
+  const context = React.useContext(CollapsibleContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Collapsible>`);
+  }
+  return context;
+}
+
+type CollapsibleProps = React.HTMLAttributes<HTMLDivElement> & {
+  open?: boolean;
+  defaultOpen?: boolean;
+  disabled?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+const Collapsible = React.forwardRef<HTMLDivElement, CollapsibleProps>(
+  (
+    {
+      open,
+      defaultOpen = false,
+      disabled = false,
+      onOpenChange,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const isControlled = open !== undefined;
+    const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+    const currentOpen = isControlled ? Boolean(open) : internalOpen;
+
+    const setOpen = React.useCallback(
+      (next: boolean) => {
+        if (disabled) return;
+        if (!isControlled) {
+          setInternalOpen(next);
+        }
+        onOpenChange?.(next);
+      },
+      [disabled, isControlled, onOpenChange]
+    );
+
+    const value = React.useMemo<CollapsibleContextValue>(
+      () => ({ open: currentOpen, disabled, setOpen }),
+      [currentOpen, disabled, setOpen]
+    );
+
+    return (
+      <CollapsibleContext.Provider value={value}>
+        <div
+          ref={ref}
+          data-state={currentOpen ? 'open' : 'closed'}
+          data-disabled={disabled ? '' : undefined}
+          className={cn(className)}
+          {...props}
+        >
+          {children}
+        </div>
+      </CollapsibleContext.Provider>
+    );
+  }
+);
+Collapsible.displayName = 'Collapsible';
+
+type CollapsibleTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+const CollapsibleTrigger = React.forwardRef<HTMLButtonElement, CollapsibleTriggerProps>(
+  ({ className, onClick, type = 'button', disabled: disabledProp, ...props }, ref) => {
+    const { open, disabled, setOpen } = useCollapsibleContext('CollapsibleTrigger');
+    const mergedDisabled = disabled || Boolean(disabledProp);
+
+    const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+      if (mergedDisabled) return;
+      onClick?.(event);
+      if (!event.defaultPrevented) {
+        setOpen(!open);
+      }
+    };
+
+    return (
+      <button
+        ref={ref}
+        type={type}
+        disabled={mergedDisabled}
+        data-state={open ? 'open' : 'closed'}
+        data-disabled={mergedDisabled ? '' : undefined}
+        aria-expanded={open}
+        aria-disabled={mergedDisabled || undefined}
+        className={cn(className)}
+        onClick={handleClick}
+        {...props}
+      />
+    );
+  }
+);
+CollapsibleTrigger.displayName = 'CollapsibleTrigger';
+
+type CollapsibleContentProps = React.HTMLAttributes<HTMLDivElement>;
+
+const CollapsibleContent = React.forwardRef<HTMLDivElement, CollapsibleContentProps>(
+  ({ className, style, children, ...props }, ref) => {
+    const { open } = useCollapsibleContext('CollapsibleContent');
+    const contentRef = React.useRef<HTMLDivElement | null>(null);
+    const mergedRef = useMergeRefs(ref, contentRef);
+    const [height, setHeight] = React.useState(0);
+
+    React.useLayoutEffect(() => {
+      const node = contentRef.current;
+      if (!node) return;
+
+      const updateHeight = () => {
+        setHeight(node.scrollHeight);
+      };
+
+      updateHeight();
+
+      if (typeof ResizeObserver !== 'undefined') {
+        const observer = new ResizeObserver(updateHeight);
+        observer.observe(node);
+        return () => {
+          observer.disconnect();
+        };
+      }
+
+      return undefined;
+    }, [children, open]);
+
+    return (
+      <div
+        ref={mergedRef}
+        data-state={open ? 'open' : 'closed'}
+        className={cn(
+          'overflow-hidden transition-[max-height,opacity] duration-200 ease-out data-[state=open]:opacity-100 data-[state=closed]:opacity-0',
+          className
+        )}
+        style={{
+          ...style,
+          maxHeight: open ? (height ? `${height}px` : '9999px') : '0px',
+          pointerEvents: open ? style?.pointerEvents ?? 'auto' : 'none',
+        }}
+        aria-hidden={!open}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+CollapsibleContent.displayName = 'CollapsibleContent';
+
+function useMergeRefs<T>(...refs: (React.Ref<T> | undefined)[]) {
+  return React.useCallback(
+    (node: T) => {
+      refs.forEach((ref) => {
+        if (!ref) return;
+        if (typeof ref === 'function') {
+          ref(node);
+        } else {
+          (ref as React.MutableRefObject<T | null>).current = node;
+        }
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    refs
+  );
+}
+
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };


### PR DESCRIPTION
## Summary
- add a client-side collapsible utility and use it to animate tree navigation expansion with shadcn-style triggers
- refine tree navigation styling, icons, and spacing while keeping active state tracking intact
- make the desktop sidebar resizable/collapsible with a draggable separator and smooth transitions

## Testing
- npx tsc --noEmit *(fails: existing missing type declarations in lib/md.ts, lib/rehypeScopeClasses.ts, lib/summaries.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68f8991ccbf88325924bac58965cbf4f