### PR TITLE
Add content preparation script to rewrite markdown references

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "prebuild": "node scripts/prepare-content.mjs",
     "dev": "next dev",
     "build": "next build",
     "export": "next export",

--- a/scripts/prepare-content.mjs
+++ b/scripts/prepare-content.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import fsp from 'fs/promises';
+import path from 'path';
+import { remark } from 'remark';
+import { visit } from 'unist-util-visit';
+
+const PROJECT_ROOT = process.cwd();
+const CONTENT_ROOT = path.join(PROJECT_ROOT, 'content');
+const PUBLIC_ROOT = path.join(PROJECT_ROOT, 'public');
+
+const INDEX_FILENAME = 'index.md';
+const IMAGE_SUFFIX = '.image';
+
+function slugify(value) {
+  return value
+    .trim()
+    .replace(/^[0-9]+-/, '')
+    .replace(/\s+/g, '-')
+    .replace(/[^a-zA-Z0-9\-]/g, '')
+    .replace(/--+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+}
+
+function numericPrefixOrNull(name) {
+  const match = name.match(/^([0-9]+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+function sortDirents(dirents) {
+  return dirents.sort((a, b) => {
+    const aNum = numericPrefixOrNull(a.name);
+    const bNum = numericPrefixOrNull(b.name);
+    if (aNum !== null && bNum !== null) return aNum - bNum;
+    if (aNum !== null) return -1;
+    if (bNum !== null) return 1;
+    return a.name.localeCompare(b.name, undefined, { numeric: true });
+  });
+}
+
+function hasIndex(dirAbs) {
+  return fs.existsSync(path.join(dirAbs, INDEX_FILENAME));
+}
+
+function ensureContentRoot() {
+  if (!fs.existsSync(CONTENT_ROOT)) {
+    throw new Error(`Content directory not found: ${CONTENT_ROOT}`);
+  }
+}
+
+function canonicalPathForEntry(slug, type, parentCollectionSlug) {
+  const base = type === 'article' && !parentCollectionSlug ? '/articles' : '/collections';
+  if (!slug) {
+    return base;
+  }
+  return `${base}/${slug}`;
+}
+
+async function walkContent(dirAbs, slugPieces, parentCollectionSlug) {
+  const results = [];
+  const dirents = sortDirents(await fsp.readdir(dirAbs, { withFileTypes: true }));
+  const childDirs = dirents.filter((entry) => entry.isDirectory());
+  const currentHasIndex = hasIndex(dirAbs);
+  const contentChildDirs = childDirs.filter((entry) => hasIndex(path.join(dirAbs, entry.name)));
+  const slug = slugPieces.join('/');
+
+  if (currentHasIndex) {
+    const type = contentChildDirs.length > 0 ? 'collection' : 'article';
+    const canonicalPath = canonicalPathForEntry(slug, type, parentCollectionSlug);
+    const entry = {
+      slug,
+      folderAbs: dirAbs,
+      indexPath: path.join(dirAbs, INDEX_FILENAME),
+      type,
+      canonicalPath,
+      canonicalUrl: `${canonicalPath}/`,
+      parentCollectionSlug: parentCollectionSlug ?? null,
+    };
+    results.push(entry);
+  }
+
+  if (currentHasIndex && contentChildDirs.length > 0) {
+    for (const child of contentChildDirs) {
+      const childAbs = path.join(dirAbs, child.name);
+      const childSlugPieces = slugPieces.length === 0
+        ? [slugify(child.name)]
+        : [...slugPieces, slugify(child.name)];
+      const childResults = await walkContent(childAbs, childSlugPieces, slug);
+      results.push(...childResults);
+    }
+    return results;
+  }
+
+  for (const child of childDirs) {
+    const childAbs = path.join(dirAbs, child.name);
+    const childSlugPieces = slugPieces.length === 0
+      ? [slugify(child.name)]
+      : [...slugPieces, slugify(child.name)];
+    const childResults = await walkContent(childAbs, childSlugPieces, parentCollectionSlug);
+    results.push(...childResults);
+  }
+
+  return results;
+}
+
+async function collectEntries() {
+  ensureContentRoot();
+  return walkContent(CONTENT_ROOT, [], null);
+}
+
+function normalizePath(p) {
+  return path.normalize(p);
+}
+
+function splitTarget(target) {
+  let pathPart = target;
+  let hash = '';
+  let query = '';
+
+  const hashIndex = pathPart.indexOf('#');
+  if (hashIndex !== -1) {
+    hash = pathPart.slice(hashIndex);
+    pathPart = pathPart.slice(0, hashIndex);
+  }
+
+  const queryIndex = pathPart.indexOf('?');
+  if (queryIndex !== -1) {
+    query = pathPart.slice(queryIndex);
+    pathPart = pathPart.slice(0, queryIndex);
+  }
+
+  return { pathPart, hash, query };
+}
+
+function isAbsoluteOrAnchor(target) {
+  if (!target) return true;
+  if (target.startsWith('#')) return true;
+  if (target.startsWith('/')) return true;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) return true;
+  return false;
+}
+
+function pathHasImageDir(absPath) {
+  const parts = absPath.split(path.sep);
+  return parts.some((segment) => segment.endsWith(IMAGE_SUFFIX));
+}
+
+function toPosixPath(p) {
+  return p.split(path.sep).join('/');
+}
+
+async function findImageDirectories(entry) {
+  const stack = [entry.folderAbs];
+  const results = [];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const dirents = await fsp.readdir(current, { withFileTypes: true });
+    for (const dirent of dirents) {
+      if (!dirent.isDirectory()) continue;
+      const full = path.join(current, dirent.name);
+      if (dirent.name.endsWith(IMAGE_SUFFIX)) {
+        results.push(full);
+        continue;
+      }
+      if (hasIndex(full)) {
+        continue;
+      }
+      stack.push(full);
+    }
+  }
+  return results;
+}
+
+async function copyDirectory(src, dest) {
+  await fsp.mkdir(dest, { recursive: true });
+  const entries = await fsp.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyDirectory(srcPath, destPath);
+    } else if (entry.isFile()) {
+      await fsp.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+function transformUrl(target, context) {
+  const trimmed = target.trim();
+  if (isAbsoluteOrAnchor(trimmed)) {
+    return { changed: false, value: target };
+  }
+
+  const { pathPart, hash, query } = splitTarget(trimmed);
+  if (!pathPart) {
+    return { changed: false, value: target };
+  }
+
+  const resolved = normalizePath(path.resolve(context.fileDir, pathPart));
+  const ext = path.extname(pathPart).toLowerCase();
+
+  if (ext === '.md' && context.indexByPath.has(resolved)) {
+    const targetEntry = context.indexByPath.get(resolved);
+    const newUrl = `${targetEntry.canonicalUrl}${query}${hash}`;
+    return { changed: true, value: newUrl };
+  }
+
+  if (pathHasImageDir(resolved)) {
+    if (!resolved.startsWith(context.entry.folderAbs)) {
+      return { changed: false, value: target };
+    }
+    const relativeToArticle = path.relative(context.entry.folderAbs, resolved);
+    if (relativeToArticle.startsWith('..')) {
+      return { changed: false, value: target };
+    }
+    const normalizedRelative = toPosixPath(relativeToArticle);
+    const newUrl = `${context.entry.canonicalPath}/${normalizedRelative}${query}${hash}`;
+    return { changed: true, value: newUrl };
+  }
+
+  return { changed: false, value: target };
+}
+
+function rewriteLinksPlugin(context) {
+  return (tree, file) => {
+    let modified = false;
+    visit(tree, ['link', 'image', 'definition'], (node) => {
+      if (!node.url || typeof node.url !== 'string') {
+        return;
+      }
+      const { changed, value } = transformUrl(node.url, context);
+      if (changed) {
+        node.url = value;
+        modified = true;
+      }
+    });
+    if (modified) {
+      file.data.modified = true;
+    }
+  };
+}
+
+async function processMarkdownFile(entry, filePath, indexByPath) {
+  const original = await fsp.readFile(filePath, 'utf8');
+  const context = {
+    fileDir: path.dirname(filePath),
+    entry,
+    indexByPath,
+  };
+  const processor = remark().use(rewriteLinksPlugin, context);
+  const file = await processor.process(original);
+  const changed = Boolean(file.data.modified);
+  if (changed) {
+    await fsp.writeFile(filePath, String(file));
+  }
+  return changed;
+}
+
+async function updateMarkdownFiles(entry, indexByPath) {
+  const dirents = await fsp.readdir(entry.folderAbs, { withFileTypes: true });
+  const mdFiles = dirents.filter((dirent) => dirent.isFile() && dirent.name.toLowerCase().endsWith('.md'));
+  const changedFiles = [];
+  for (const md of mdFiles) {
+    const filePath = path.join(entry.folderAbs, md.name);
+    const changed = await processMarkdownFile(entry, filePath, indexByPath);
+    if (changed) {
+      changedFiles.push(filePath);
+    }
+  }
+  return changedFiles;
+}
+
+async function copyImageAssets(entry) {
+  const imageDirs = await findImageDirectories(entry);
+  if (imageDirs.length === 0) {
+    return [];
+  }
+  const copied = [];
+  for (const srcDir of imageDirs) {
+    const relativeDir = path.relative(entry.folderAbs, srcDir);
+    if (relativeDir.startsWith('..')) {
+      continue;
+    }
+    const destBase = path.join(
+      PUBLIC_ROOT,
+      entry.canonicalPath.replace(/^\//, ''),
+      relativeDir
+    );
+    await fsp.rm(destBase, { recursive: true, force: true });
+    await copyDirectory(srcDir, destBase);
+    copied.push({ from: srcDir, to: destBase });
+  }
+  return copied;
+}
+
+async function main() {
+  ensureContentRoot();
+  const entries = await collectEntries();
+  const indexByPath = new Map(entries.map((entry) => [normalizePath(entry.indexPath), entry]));
+
+  const summary = {
+    updatedFiles: [],
+    copiedAssets: [],
+  };
+
+  for (const entry of entries) {
+    const updated = await updateMarkdownFiles(entry, indexByPath);
+    summary.updatedFiles.push(...updated);
+    const copied = await copyImageAssets(entry);
+    summary.copiedAssets.push(...copied);
+  }
+
+  if (summary.updatedFiles.length > 0) {
+    console.log(`Updated markdown references in ${summary.updatedFiles.length} file(s).`);
+  }
+  if (summary.copiedAssets.length > 0) {
+    for (const { from, to } of summary.copiedAssets) {
+      console.log(`Copied assets from ${from} to ${to}`);
+    }
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a Node.js publishing helper that walks the content tree, rewrites relative markdown links, and mirrors `.image` asset folders under `public`
- integrate the helper as an automatic `prebuild` step so article URLs and assets are normalized before `next build`

## Testing
- npm run build *(fails: existing type error in lib/md.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68f899b916fc832596516f932a860bc3