### PR TITLE
Add knowledge path breadcrumbs

### DIFF
--- a/app/articles/[...slug]/page.tsx
+++ b/app/articles/[...slug]/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { ArticleViewToggle } from '../../../components/ArticleViewToggle';
 import { ArticleContent } from '../../../components/ArticleContent';
-import { getAllArticles, getArticleBySlug, getArticleCanonicalUrl } from '../../../lib/content/content';
+import {
+  getAllArticles,
+  getArticleBySlug,
+  getArticleCanonicalUrl,
+  getKnowledgePathForSlug,
+} from '../../../lib/content/content';
 import { Suspense } from 'react';
 import { CopyCodeButtons } from '@/components/CopyCodeButtons';
 
@@ -37,7 +42,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ArticlePage({ params }: PageProps) {
   const slug = Array.isArray(params.slug) ? params.slug.join('/') : params.slug ?? '';
-  const article = await getArticleBySlug(slug);
+  const [article, knowledgePath] = await Promise.all([
+    getArticleBySlug(slug),
+    getKnowledgePathForSlug(slug),
+  ]);
   if (!article || article.collectionSlug) {
     notFound();
   }
@@ -56,7 +64,7 @@ export default async function ArticlePage({ params }: PageProps) {
 
       {/* If ArticleContent uses client hooks, wrap it too */}
       <Suspense fallback={null}>
-        <ArticleContent article={article} />
+        <ArticleContent article={article} knowledgePath={knowledgePath} />
       </Suspense>
 
       <CopyCodeButtons />

--- a/app/collections/[...slug]/page.tsx
+++ b/app/collections/[...slug]/page.tsx
@@ -12,6 +12,7 @@ import {
   getCollectionBySlug,
   getCollectionCanonicalUrl,
   getCollections,
+  getKnowledgePathForSlug,
 } from '../../../lib/content/content';
 import { formatDate } from '../../../lib/format';
 
@@ -86,7 +87,10 @@ export default async function CollectionSlugPage({ params }: PageProps) {
     notFound();
   }
 
-  const parentCollection = await getCollectionBySlug(article.collectionSlug);
+  const [parentCollection, knowledgePath] = await Promise.all([
+    getCollectionBySlug(article.collectionSlug),
+    getKnowledgePathForSlug(slug),
+  ]);
 
   return (
     <div className="flex flex-col gap-6">
@@ -106,7 +110,7 @@ export default async function CollectionSlugPage({ params }: PageProps) {
       </div>
 
       <Suspense fallback={null}>
-        <ArticleContent article={article} />
+        <ArticleContent article={article} knowledgePath={knowledgePath} />
       </Suspense>
     </div>
   );

--- a/components/ArticleContent.tsx
+++ b/components/ArticleContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Article } from '../lib/content/types';
+import { Article, KnowledgePathItem } from '../lib/content/types';
 import Image from 'next/image';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { useIsSummaryView } from './ArticleViewToggle';
@@ -9,13 +9,35 @@ import { TagBadge } from './TagBadge';
 import { withBasePath } from '../lib/paths';
 import { GiscusComments } from './GiscusComments';
 
-export function ArticleContent({ article }: { article: Article }) {
+export function ArticleContent({
+  article,
+  knowledgePath = [],
+}: {
+  article: Article;
+  knowledgePath?: KnowledgePathItem[];
+}) {
   const isSummary = useIsSummaryView();
 
   return (
     <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_280px] lg:gap-16">
       <article className="prose prose-lg prose-slate max-w-none dark:prose-invert">
         <header className="not-prose mb-8 flex flex-col gap-4">
+          {knowledgePath.length > 0 && (
+            <nav aria-label="Knowledge path" className="text-sm text-slate-600 dark:text-slate-300">
+              <ol className="flex flex-wrap items-center gap-2">
+                {knowledgePath.map((node, index) => (
+                  <li key={node.slug} className="flex items-center gap-2">
+                    <span className="font-medium">{node.title}</span>
+                    {index < knowledgePath.length - 1 && (
+                      <span aria-hidden="true" className="text-slate-400">
+                        /
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ol>
+            </nav>
+          )}
           <div className="space-y-2">
             <h1 className="text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">{article.title}</h1>
             <div className="flex flex-wrap items-center gap-3 text-sm text-slate-500 dark:text-slate-400">

--- a/lib/content/types.ts
+++ b/lib/content/types.ts
@@ -56,6 +56,11 @@ export type Heading = {
   level: number;
 };
 
+export type KnowledgePathItem = {
+  title: string;
+  slug: string;
+};
+
 export type Article = {
   slug: string;
   title: string;


### PR DESCRIPTION
## Summary
- add helper to derive knowledge paths from the subject tree
- pass knowledge paths to article rendering for standalone and collection entries
- display the article's knowledge path as a breadcrumb chain above the title

## Testing
- npm run lint (fails waiting for interactive config)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f700fc20c8325a58d889ce4173c68)