### PR TITLE
Add website tab icon (app/icon.svg)

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,12 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Articles website icon">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#2563eb" />
-      <stop offset="100%" stop-color="#1d4ed8" />
-    </linearGradient>
-  </defs>
-  <rect width="64" height="64" rx="14" fill="url(#bg)" />
-  <path d="M15 18a3 3 0 0 1 3-3h13c4.3 0 8 1.6 10 4 2-2.4 5.7-4 10-4h-1a3 3 0 0 1 3 3v28a2 2 0 0 1-2.8 1.8A20 20 0 0 0 41 45c-3 0-5.7.6-8 1.9-2.3-1.3-5-1.9-8-1.9a20 20 0 0 0-7.2 1.8A2 2 0 0 1 15 45V18z" fill="#fff" opacity="0.95"/>
-  <path d="M32 19v28" stroke="#1d4ed8" stroke-width="2.5" stroke-linecap="round" />
-  <path d="M22 25h7M22 30h7M22 35h7M35 25h7M35 30h7M35 35h7" stroke="#1d4ed8" stroke-width="2" stroke-linecap="round" opacity="0.8"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- White circular background -->
+  <circle cx="50" cy="50" r="48" fill="white"/>
+
+  <!-- Centered Blue S -->
+  <text x="50"
+        y="50"
+        text-anchor="middle"
+        dominant-baseline="middle"
+        font-family="Arial, Helvetica, sans-serif"
+        font-size="60"
+        font-weight="700"
+        fill="#1E3A8A">
+    S
+  </text>
 </svg>

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Articles website icon">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)" />
+  <path d="M15 18a3 3 0 0 1 3-3h13c4.3 0 8 1.6 10 4 2-2.4 5.7-4 10-4h-1a3 3 0 0 1 3 3v28a2 2 0 0 1-2.8 1.8A20 20 0 0 0 41 45c-3 0-5.7.6-8 1.9-2.3-1.3-5-1.9-8-1.9a20 20 0 0 0-7.2 1.8A2 2 0 0 1 15 45V18z" fill="#fff" opacity="0.95"/>
+  <path d="M32 19v28" stroke="#1d4ed8" stroke-width="2.5" stroke-linecap="round" />
+  <path d="M22 25h7M22 30h7M22 35h7M35 25h7M35 30h7M35 35h7" stroke="#1d4ed8" stroke-width="2" stroke-linecap="round" opacity="0.8"/>
+</svg>

--- a/content/Computer Science/DSP & Acoustic Fundamentals/3-Envelopes & Dynamics/1-Envelope/index.md
+++ b/content/Computer Science/DSP & Acoustic Fundamentals/3-Envelopes & Dynamics/1-Envelope/index.md
@@ -14,7 +14,6 @@ At the simplest level, an envelope is just a curve. It tells a parameter what to
 
 That is the key idea: an envelope is not really “about volume.” It is about **change over time**.
 
----
 
 ## 1. The Intuition: Sounds Are Events, Not Static Objects
 


### PR DESCRIPTION
### Motivation
- Provide a browser tab icon (favicon) so the site shows an identifiable icon in tabs and bookmarks.

### Description
- Add a new App Router SVG icon at `app/icon.svg` containing a high-contrast book-style mark on a blue rounded-square background to serve as the site favicon and `Closes #28`.

### Testing
- Ran `npm run dev:next` and confirmed the dev server served `/icon.svg` with `HTTP/1.1 200 OK` and a screenshot was captured, and attempted `npm run build` which failed due to an existing TypeScript error in `lib/md.ts` unrelated to this favicon change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4ab21f008325ac105f1b3ce3f258)